### PR TITLE
Adding support for Vibe.d sockets

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,9 +1,21 @@
 {
 	"name": "statsd4d",
-	"description": "A statsd client for D",
+	"description": "A statsd client implementation",
 	"authors": ["Thomas Daehling"],
 	"homepage": "http://www.github.com/daehlith/statsd4d/",
 	"license": "MIT",
 	"targetPath": ".build",
 	"targetType": "library",
+
+	"configurations": [
+		{
+			"name": "library",
+		},
+		{
+			"name": "vibed",
+			"dependencies": {
+				"vibe-d:core": ">=0.7.28",
+			},
+		},
+	],
 }


### PR DESCRIPTION
Compile the library with `--config=vibed` to use vibe.d's network module instead of standard library sockets.

Fixes #3
